### PR TITLE
Update sparsebundlefs.cpp

### DIFF
--- a/sparsebundlefs.cpp
+++ b/sparsebundlefs.cpp
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <syslog.h>
 #include <string.h>
+#include <unistd.h>
 #include <sys/resource.h>
 
 #include <algorithm>


### PR DESCRIPTION
Updating to fix errors
sparsebundlefs.cpp:171:56: error: 'pread' was not declared in this scope
sparsebundlefs.cpp:172:24: error: 'close' was not declared in this scope
