### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To mount a `.sparsebundle` disk image, execute the following command:
 
 For example:
 
-    sparsebundlefs ~/MyDiskImage.sparsebundle /tmp/my-disk-image
+    sparsebundlefs -o allow_root ~/MyDiskImage.sparsebundle /tmp/my-disk-image
 
 This will give you a directory at the mount point with a single `sparsebundle.dmg` file.
 


### PR DESCRIPTION
adding the allow_root option there, as its required for most of the subsequent commands such as mounting with a loopback device.  Took me ages to figure out why those where getting permission denied despite being root.